### PR TITLE
Add editor props customization in docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -102,4 +102,19 @@ export default {
     )
   }
 }
+
+## Customize editor props
+
+If you want to change the [editor props](https://github.com/koca/vue-prism-editor#props), you can add the props after the langArray
+
+````md
+```vue live {lineNumbers:true,readonly:true}
+<button>example</button>
+```
+````
+
+...will have this result.
+
+```vue live {lineNumbers:true,readonly:true}
+<button>example</button>
 ```


### PR DESCRIPTION
Hi, awesome job with vue-styleguidist packages.

Recently I had to customize the editor props from vue live. I realized that it is not documented how to do this. I had to look into the code to identify how to do this.

So this PR is adding into the docs how to do this customization. It could help others with the same issue.